### PR TITLE
website and webmail in different servers

### DIFF
--- a/apache.sh
+++ b/apache.sh
@@ -44,8 +44,8 @@ echo "$start_tag
         AllowOverride All
         </Directory>
         DocumentRoot /var/www/vhosts/$mydomain/httpdocs
-        ServerName $mydomain
-	Redirect permanent /mail https://$mydomain/mail
+        ServerName webmail.$mydomain
+	Redirect permanent / https://webmail.$mydomain
 </VirtualHost>
 
 NameVirtualHost *:443
@@ -58,9 +58,8 @@ NameVirtualHost *:443
         <Directory /var/www/vhosts/$mydomain/httpsdocs>
         AllowOverride All
         </Directory>
-        DocumentRoot /var/www/vhosts/$mydomain/httpsdocs
-        ServerName $mydomain
-	Alias /mail /usr/local/squirrelmail/www
+        ServerName webmail.$mydomain
+	DocumentRoot /usr/local/squirrelmail/www
 
         <Directory /usr/local/squirrelmail/www>
         Options None


### PR DESCRIPTION
I understand that using example.com/mail for webmail implies that example.com must be in same server. This is not the case if website is in S3/CloudFront/LoadBalancing or another EC2 instance.
So I suggest using webmail.example.com for HTTP/HTTPS webmail access.
You will need to update Route 53 settings in tutorial.
